### PR TITLE
Update bibulous.py: bugfix/redundant-variable

### DIFF
--- a/bibulous.py
+++ b/bibulous.py
@@ -2479,8 +2479,6 @@ class Bibdata(object):
                 return(self.options[option_name])
             else:
                 return(self.options['undefstr'])
-        else:
-            result = varname
         return(varname)
 
     ## =============================

--- a/bibulous.py
+++ b/bibulous.py
@@ -4209,7 +4209,7 @@ def get_edition_ordinal(edition_field, disable=None):
         return(edition_field)
 
     trans = {'first':'1', 'second':'2', 'third':'3', 'fourth':'4', 'fifth':'5', 'sixth':'6', 'seventh':'7',
-             'eighth':'8', 'ninth':'10', 'tenth':'10', 'eleventh':'11', 'twelfth':'12', 'thirteenth':'13',
+             'eighth':'8', 'ninth':'9', 'tenth':'10', 'eleventh':'11', 'twelfth':'12', 'thirteenth':'13',
              'fourteenth':'14', 'fifteenth':'15', 'sixteenth':'16', 'seventeenth':'17', 'eighteenth':'18',
              'nineteenth':'19', 'twentieth':'20'}
 


### PR DESCRIPTION
A variable in the 'format_operator_arg' function is called 'result' and is assigned but not used or returned by the function.  The function works just as well with the two proposed lines removed, unless this is a placeholder for further development?